### PR TITLE
Experiment: Replace global mutable variables for random number generators

### DIFF
--- a/rosomaxa/src/utils/mod.rs
+++ b/rosomaxa/src/utils/mod.rs
@@ -18,6 +18,9 @@ pub use self::noise::*;
 mod parallel;
 pub use self::parallel::*;
 
+mod pure_random;
+pub use self::pure_random::*;
+
 mod random;
 pub use self::random::*;
 

--- a/rosomaxa/src/utils/parallel.rs
+++ b/rosomaxa/src/utils/parallel.rs
@@ -2,6 +2,7 @@
 #[path = "../../tests/unit/utils/parallel_test.rs"]
 mod parallel_test;
 
+pub use self::actual::into_map_reduce;
 pub use self::actual::map_reduce;
 pub use self::actual::parallel_collect;
 pub use self::actual::parallel_foreach_mut;
@@ -68,6 +69,18 @@ mod actual {
         R: Send,
     {
         source.par_iter().map(map_op).reduce(default_op, reduce_op)
+    }
+
+    /// Performs map reduce operations in parallel.
+    pub fn into_map_reduce<T, FM, FR, FD, R>(source: Vec<T>, map_op: FM, default_op: FD, reduce_op: FR) -> R
+        where
+            T: Send + Sync,
+            FM: Fn(T) -> R + Sync + Send,
+            FR: Fn(R, R) -> R + Sync + Send,
+            FD: Fn() -> R + Sync + Send,
+            R: Send,
+    {
+        source.into_par_iter().map(map_op).reduce(default_op, reduce_op)
     }
 
     /// Performs mutable foreach in parallel.

--- a/rosomaxa/src/utils/pure_random.rs
+++ b/rosomaxa/src/utils/pure_random.rs
@@ -1,0 +1,131 @@
+use rand::prelude::*;
+use rand::Error;
+
+
+/// Provides the way to use randomized values in generic way.
+pub trait PureRandom {
+    /// Creates a new RNG, different for every call.
+    fn new_pure_random(&mut self) -> Self;
+
+    /// Produces integral random value, uniformly distributed on the closed interval [min, max]
+    fn uniform_int(&mut self, min: i32, max: i32) -> i32;
+
+    /// Produces real random value, uniformly distributed on the closed interval [min, max)
+    fn uniform_real(&mut self, min: f64, max: f64) -> f64;
+    /// Flips a coin and returns true if it is "heads", false otherwise.
+    fn is_head_not_tails(&mut self) -> bool;
+
+    /// Tests probability value in (0., 1.) range.
+    fn is_hit(&mut self, probability: f64) -> bool;
+
+    /// Returns an index from collected with probability weight.
+    /// Uses exponential distribution where the weights are the rate of the distribution (lambda)
+    /// and selects the smallest sampled value.
+    fn weighted(&mut self, weights: &[usize]) -> usize;
+}
+
+/// A default random implementation.
+pub struct DefaultPureRandom {
+    rng: SmallRng,
+}
+
+impl DefaultPureRandom {
+    /// This behaves like the trait `Copy`, but we don't implement the trait, as usually this behaviour
+    /// is not desired for random number generators
+    ///
+    /// In general, we probably don't want to use this method too often as the return value will
+    /// behave exactly as the original value. If we have a single (global) instance of this struct,
+    /// it should probably be mutable, so that newly constructed instances can be different for each call.
+    #[inline]
+    pub fn generate_copy(&self) -> Self {
+        Self { rng: self.rng.clone() }
+    }
+
+    /// Creates an instance of `DefaultPureRandom` with repeatable (predictable) random generation.
+    #[inline]
+    pub fn with_seed(seed: u64) -> Self {
+        Self { rng: SmallRng::seed_from_u64(seed) }
+    }
+
+    /// Creates an instance of `DefaultPureRandom` with reproducible behavior.
+    #[inline]
+    pub fn for_tests() -> Self {
+        Self { rng: SmallRng::seed_from_u64(1234567890) }
+    }
+
+    /// Creates a randomly initialized instance of `DefaultPureRandom`.
+    #[inline]
+    pub fn new_random() -> Self {
+        Self { rng: SmallRng::from_rng(thread_rng()).expect("cannot get RNG from thread rng") }
+    }
+}
+
+impl PureRandom for DefaultPureRandom {
+    #[inline]
+    fn new_pure_random(&mut self) -> Self {
+        Self { rng: SmallRng::seed_from_u64(self.next_u64())}
+    }
+    #[inline]
+    fn uniform_int(&mut self, min: i32, max: i32) -> i32 {
+        if min == max {
+            return min;
+        }
+
+        assert!(min < max);
+        self.rng.gen_range(min..max + 1)
+    }
+
+    #[inline]
+    fn uniform_real(&mut self, min: f64, max: f64) -> f64 {
+        if (min - max).abs() < f64::EPSILON {
+            return min;
+        }
+
+        assert!(min < max);
+        self.rng.gen_range(min..max)
+    }
+
+    #[inline]
+    fn is_head_not_tails(&mut self) -> bool {
+        self.rng.gen_bool(0.5)
+    }
+
+    #[inline]
+    fn is_hit(&mut self, probability: f64) -> bool {
+        self.gen_bool(probability.clamp(0., 1.))
+    }
+
+    #[inline]
+    fn weighted(&mut self, weights: &[usize]) -> usize {
+        weights
+            .iter()
+            .zip(0_usize..)
+            .map(|(&weight, index)| (-self.uniform_real(0., 1.).ln() / weight as f64, index))
+            .min_by(|a, b| a.0.partial_cmp(&b.0).unwrap())
+            .unwrap()
+            .1
+    }
+}
+
+/// Reimplementing RngCore helps to set breakpoints and also hides the usage of SmallRng.
+impl RngCore for DefaultPureRandom {
+    #[inline]
+    fn next_u32(&mut self) -> u32 {
+        self.rng.next_u32()
+    }
+
+    #[inline]
+    fn next_u64(&mut self) -> u64 {
+        self.rng.next_u64()
+    }
+
+    #[inline]
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.rng.fill_bytes(dest)
+    }
+
+    #[inline]
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
+        self.rng.try_fill_bytes(dest)
+    }
+}

--- a/vrp-core/src/construction/clustering/vicinity/mod.rs
+++ b/vrp-core/src/construction/clustering/vicinity/mod.rs
@@ -184,10 +184,10 @@ fn get_check_insertion_fn(
     actor_filter: Arc<dyn Fn(&Actor) -> bool + Send + Sync>,
 ) -> impl Fn(&Job) -> Result<(), i32> {
     move |job: &Job| -> Result<(), i32> {
-        let eval_ctx = EvaluationContext {
+        let mut eval_ctx = EvaluationContext {
             goal: &insertion_ctx.problem.goal,
             job,
-            leg_selection: &LegSelection::Exhaustive,
+            leg_selection: LegSelection::Exhaustive,
             result_selector: &BestResultSelector::default(),
         };
 
@@ -199,7 +199,7 @@ fn get_check_insertion_fn(
             .try_fold(Err(-1), |_, route_ctx| {
                 let result = eval_job_insertion_in_route(
                     &insertion_ctx,
-                    &eval_ctx,
+                    &mut eval_ctx,
                     route_ctx,
                     InsertionPosition::Any,
                     InsertionResult::make_failure(),

--- a/vrp-core/src/construction/heuristics/evaluators.rs
+++ b/vrp-core/src/construction/heuristics/evaluators.rs
@@ -19,7 +19,7 @@ pub struct EvaluationContext<'a> {
     /// A job which is about to be inserted.
     pub job: &'a Job,
     /// A leg selection mode.
-    pub leg_selection: &'a LegSelection,
+    pub leg_selection: LegSelection,
     /// A result selector.
     pub result_selector: &'a (dyn ResultSelector + Send + Sync),
 }
@@ -39,7 +39,7 @@ pub enum InsertionPosition {
 /// at given position constraint.
 pub fn eval_job_insertion_in_route(
     insertion_ctx: &InsertionContext,
-    eval_ctx: &EvaluationContext,
+    eval_ctx: &mut EvaluationContext,
     route_ctx: &RouteContext,
     position: InsertionPosition,
     alternative: InsertionResult,
@@ -84,7 +84,7 @@ pub fn eval_job_insertion_in_route(
 /// Evaluates possibility to preform insertion in route context only.
 /// NOTE: doesn't evaluate constraints on route level.
 pub fn eval_job_constraint_in_route(
-    eval_ctx: &EvaluationContext,
+    eval_ctx: &mut EvaluationContext,
     route_ctx: &RouteContext,
     position: InsertionPosition,
     route_costs: InsertionCost,
@@ -98,7 +98,7 @@ pub fn eval_job_constraint_in_route(
 
 pub(crate) fn eval_single_constraint_in_route(
     insertion_ctx: &InsertionContext,
-    eval_ctx: &EvaluationContext,
+    eval_ctx: &mut EvaluationContext,
     route_ctx: &RouteContext,
     single: &Arc<Single>,
     position: InsertionPosition,
@@ -119,7 +119,7 @@ pub(crate) fn eval_single_constraint_in_route(
 }
 
 fn eval_single(
-    eval_ctx: &EvaluationContext,
+    eval_ctx: &mut EvaluationContext,
     route_ctx: &RouteContext,
     single: &Arc<Single>,
     position: InsertionPosition,
@@ -151,7 +151,7 @@ fn eval_single(
 }
 
 fn eval_multi(
-    eval_ctx: &EvaluationContext,
+    eval_ctx: &mut EvaluationContext,
     route_ctx: &RouteContext,
     multi: &Arc<Multi>,
     position: InsertionPosition,
@@ -244,7 +244,7 @@ fn analyze_insertion_in_route(
                 init
             }
         }
-        None => eval_ctx.leg_selection.sample_best(
+        None => eval_ctx.leg_selection.generate_copy().sample_best(
             route_ctx,
             eval_ctx.job,
             init.index,

--- a/vrp-core/src/construction/heuristics/insertions.rs
+++ b/vrp-core/src/construction/heuristics/insertions.rs
@@ -258,7 +258,7 @@ impl InsertionHeuristic {
         insertion_ctx: InsertionContext,
         job_selector: &(dyn JobSelector + Send + Sync),
         route_selector: &(dyn RouteSelector + Send + Sync),
-        leg_selection: &LegSelection,
+        mut leg_selection: LegSelection,
         result_selector: &(dyn ResultSelector + Send + Sync),
     ) -> InsertionContext {
         let mut insertion_ctx = insertion_ctx;
@@ -275,7 +275,7 @@ impl InsertionHeuristic {
             let routes = route_selector.select(&insertion_ctx, jobs.as_slice()).collect::<Vec<_>>();
 
             let result =
-                self.insertion_evaluator.evaluate_all(&insertion_ctx, &jobs, &routes, leg_selection, result_selector);
+                self.insertion_evaluator.evaluate_all(&insertion_ctx, &jobs, &routes, leg_selection.next(), result_selector);
 
             match result {
                 InsertionResult::Success(success) => {

--- a/vrp-core/src/construction/probing/repair_solution.rs
+++ b/vrp-core/src/construction/probing/repair_solution.rs
@@ -88,7 +88,6 @@ fn synchronize_jobs(
     goal: &GoalContext,
 ) -> HashMap<Job, Vec<Arc<Single>>> {
     let position = InsertionPosition::Last;
-    let leg_selection = LegSelection::Exhaustive;
     let result_selector = BestResultSelector::default();
 
     let (synchronized_jobs, _) = route_ctx
@@ -106,17 +105,17 @@ fn synchronize_jobs(
                 let is_invalid_multi_job = invalid_multi_job_ids.contains(&job);
 
                 if !is_already_processed && !is_invalid_multi_job {
-                    let eval_ctx = EvaluationContext {
+                    let mut eval_ctx = EvaluationContext {
                         goal,
                         job: &job,
-                        leg_selection: &leg_selection,
+                        leg_selection: LegSelection::Exhaustive,
                         result_selector: &result_selector,
                     };
                     let route_ctx = new_insertion_ctx.solution.routes.get(route_idx).unwrap();
 
                     let insertion_result = eval_single_constraint_in_route(
                         new_insertion_ctx,
-                        &eval_ctx,
+                        &mut eval_ctx,
                         route_ctx,
                         single,
                         position,

--- a/vrp-core/src/solver/processing/unassignment_reason.rs
+++ b/vrp-core/src/solver/processing/unassignment_reason.rs
@@ -17,14 +17,13 @@ impl HeuristicSolutionProcessing for UnassignmentReason {
         let mut insertion_ctx = solution;
 
         let unassigned = insertion_ctx.solution.unassigned.drain().collect::<Vec<_>>();
-        let leg_selection = LegSelection::Exhaustive;
         let result_selector = BestResultSelector::default();
 
         let unassigned = parallel_into_collect(unassigned, |(job, code)| {
-            let eval_ctx = EvaluationContext {
+            let mut eval_ctx = EvaluationContext {
                 goal: &insertion_ctx.problem.goal,
                 job: &job,
-                leg_selection: &leg_selection,
+                leg_selection: LegSelection::Exhaustive,
                 result_selector: &result_selector,
             };
             let details = insertion_ctx
@@ -36,7 +35,7 @@ impl HeuristicSolutionProcessing for UnassignmentReason {
                         .map(|leg_idx| {
                             eval_job_insertion_in_route(
                                 &insertion_ctx,
-                                &eval_ctx,
+                                &mut eval_ctx,
                                 route_ctx,
                                 InsertionPosition::Concrete(leg_idx),
                                 InsertionResult::make_failure(),

--- a/vrp-core/src/solver/search/local/exchange_intra_route.rs
+++ b/vrp-core/src/solver/search/local/exchange_intra_route.rs
@@ -39,23 +39,23 @@ impl LocalOperator for ExchangeIntraRouteRandom {
                 new_insertion_ctx.solution.required.push(job.clone());
                 new_insertion_ctx.problem.goal.accept_route_state(new_route_ctx);
 
-                let leg_selection = LegSelection::Stochastic(random.clone());
+                let leg_selection = LegSelection::random_stochastic(&random);
                 let result_selector = NoiseResultSelector::new(Noise::new_with_addition(
                     self.probability,
                     self.noise_range,
                     random.clone(),
                 ));
-                let eval_ctx = EvaluationContext {
+                let mut eval_ctx = EvaluationContext {
                     goal: &insertion_ctx.problem.goal,
                     job: &job,
-                    leg_selection: &leg_selection,
+                    leg_selection: leg_selection,
                     result_selector: &result_selector,
                 };
 
                 let new_route_ctx = new_insertion_ctx.solution.routes.get(route_idx).unwrap();
                 let insertion = eval_job_insertion_in_route(
                     &new_insertion_ctx,
-                    &eval_ctx,
+                    &mut eval_ctx,
                     new_route_ctx,
                     InsertionPosition::Any,
                     InsertionResult::make_failure(),

--- a/vrp-core/src/solver/search/local/exchange_swap_star.rs
+++ b/vrp-core/src/solver/search/local/exchange_swap_star.rs
@@ -11,6 +11,7 @@ use rand::seq::SliceRandom;
 use rosomaxa::utils::*;
 use std::iter::once;
 use std::sync::RwLock;
+use rand::RngCore;
 
 /// Implements a SWAP* algorithm described in "Hybrid Genetic Search for the CVRP:
 /// Open-Source Implementation and SWAP* Neighborhood" by Thibaut Vidal.
@@ -32,7 +33,7 @@ impl ExchangeSwapStar {
     /// Creates a new instance of `ExchangeSwapStar`.
     pub fn new(random: Arc<dyn Random + Send + Sync>, quota_limit: usize) -> Self {
         Self {
-            leg_selection: LegSelection::Stochastic(random),
+            leg_selection: LegSelection::random_stochastic(&random),
             result_selector: Box::<BestResultSelector>::default(),
             quota_limit,
         }
@@ -61,7 +62,7 @@ impl LocalOperator for ExchangeSwapStar {
             let is_quota_reached = try_exchange_jobs_in_routes(
                 &mut insertion_ctx,
                 route_pair,
-                &self.leg_selection,
+                self.leg_selection.generate_copy(),
                 self.result_selector.as_ref(),
             );
 
@@ -77,7 +78,7 @@ impl LocalOperator for ExchangeSwapStar {
 }
 
 /// Encapsulates common data used by search phase.
-type SearchContext<'a> = (&'a InsertionContext, &'a LegSelection, &'a (dyn ResultSelector + Send + Sync));
+type SearchContext<'a> = (&'a InsertionContext, LegSelection, &'a (dyn ResultSelector + Send + Sync));
 
 fn get_route_by_idx(insertion_ctx: &InsertionContext, route_idx: usize) -> &RouteContext {
     insertion_ctx.solution.routes.get(route_idx).expect("invalid route index")
@@ -91,7 +92,8 @@ fn get_evaluation_context<'a>(search_ctx: &'a SearchContext, job: &'a Job) -> Ev
     EvaluationContext {
         goal: search_ctx.0.problem.goal.as_ref(),
         job,
-        leg_selection: search_ctx.1,
+        // TODO: We have to think again whether a copy is what we want here
+        leg_selection: search_ctx.1.generate_copy(),
         result_selector: search_ctx.2,
     }
 }
@@ -128,7 +130,7 @@ fn create_route_pairs(insertion_ctx: &InsertionContext, route_pairs_threshold: u
                         .map(|inner_idx| (outer_idx, inner_idx))
                 })
                 .collect::<Vec<_>>();
-            SelectionSamplingIterator::new(distances.into_iter(), route_pairs_threshold, random.clone()).collect()
+            SelectionSamplingIterator::new(distances.into_iter(), route_pairs_threshold, DefaultPureRandom::with_seed(random.get_rng().next_u64())).collect()
         })
         .unwrap_or_else(|| {
             let route_count = insertion_ctx.solution.routes.len();
@@ -140,7 +142,7 @@ fn create_route_pairs(insertion_ctx: &InsertionContext, route_pairs_threshold: u
                         .map(move |inner_idx| (outer_idx, inner_idx))
                 })
                 .collect::<Vec<_>>();
-            SelectionSamplingIterator::new(all_route_pairs.into_iter(), route_pairs_threshold, random.clone()).collect()
+            SelectionSamplingIterator::new(all_route_pairs.into_iter(), route_pairs_threshold, DefaultPureRandom::with_seed(random.get_rng().next_u64())).collect()
         })
 }
 
@@ -158,10 +160,13 @@ fn find_insertion_cost(search_ctx: &SearchContext, job: &Job, route_ctx: &RouteC
             search_ctx.0.problem.goal.accept_route_state(&mut route_ctx);
 
             // NOTE This is not the best approach for multi-jobs
-            let &(insertion_ctx, leg_selection, result_selector) = search_ctx;
+            let (insertion_ctx, leg_selection, _) = search_ctx;
+            // let evaluation_context = EvaluationContext {}
+            // TODO: Think about whether a copy of `leg_selection` is the right thing.
+            let leg_selection = leg_selection.generate_copy();
             eval_job_insertion_in_route(
                 insertion_ctx,
-                &EvaluationContext { goal: insertion_ctx.problem.goal.as_ref(), job, leg_selection, result_selector },
+                &mut EvaluationContext { goal: insertion_ctx.problem.goal.as_ref(), job, leg_selection, result_selector: search_ctx.2 },
                 &route_ctx,
                 InsertionPosition::Concrete(idx - 1),
                 InsertionResult::make_failure(),
@@ -186,9 +191,9 @@ fn find_in_place_result(
 
     let route_ctx = remove_job_with_copy(search_ctx, extract_job, route_ctx);
 
-    let eval_ctx = get_evaluation_context(search_ctx, insert_job);
+    let mut eval_ctx = get_evaluation_context(search_ctx, insert_job);
 
-    eval_job_insertion_in_route(search_ctx.0, &eval_ctx, &route_ctx, position, InsertionResult::make_failure())
+    eval_job_insertion_in_route(search_ctx.0, &mut eval_ctx, &route_ctx, position, InsertionResult::make_failure())
 }
 
 fn find_top_results(
@@ -200,14 +205,14 @@ fn find_top_results(
 
     jobs.iter()
         .map(|job| {
-            let eval_ctx = get_evaluation_context(search_ctx, job);
+            let mut eval_ctx = get_evaluation_context(search_ctx, job);
 
             let mut results = (0..legs_count)
                 .map(InsertionPosition::Concrete)
                 .map(|position| {
                     eval_job_insertion_in_route(
                         search_ctx.0,
-                        &eval_ctx,
+                        &mut eval_ctx,
                         route_ctx,
                         position,
                         InsertionResult::make_failure(),
@@ -292,7 +297,7 @@ fn remove_job_with_copy(search_ctx: &SearchContext, job: &Job, route_ctx: &Route
 fn try_exchange_jobs_in_routes(
     insertion_ctx: &mut InsertionContext,
     route_pair: (usize, usize),
-    leg_selection: &LegSelection,
+    mut leg_selection: LegSelection,
     result_selector: &(dyn ResultSelector + Send + Sync),
 ) -> bool {
     let quota = insertion_ctx.environment.quota.clone();
@@ -302,7 +307,7 @@ fn try_exchange_jobs_in_routes(
         return true;
     }
 
-    let search_ctx: SearchContext = (insertion_ctx, leg_selection, result_selector);
+    let search_ctx: SearchContext = (insertion_ctx, leg_selection.next(), result_selector);
     let (outer_idx, inner_idx) = route_pair;
 
     let outer_route_ctx = get_route_by_idx(insertion_ctx, outer_idx);
@@ -373,7 +378,7 @@ fn try_exchange_jobs_in_routes(
 fn try_exchange_jobs(
     insertion_ctx: &mut InsertionContext,
     insertion_pair: (InsertionResult, InsertionResult),
-    leg_selection: &LegSelection,
+    mut leg_selection: LegSelection,
     result_selector: &(dyn ResultSelector + Send + Sync),
 ) {
     if let (InsertionResult::Success(outer_success), InsertionResult::Success(inner_success)) = insertion_pair {
@@ -404,11 +409,11 @@ fn try_exchange_jobs(
                 let position = if position < removed_idx || position == 0 { position } else { position - 1 };
                 let position = InsertionPosition::Concrete(position);
 
-                let search_ctx: SearchContext = (insertion_ctx, leg_selection, result_selector);
-                let eval_ctx = get_evaluation_context(&search_ctx, &success.job);
+                let search_ctx: SearchContext = (insertion_ctx, leg_selection.next(), result_selector);
+                let mut eval_ctx = get_evaluation_context(&search_ctx, &success.job);
                 let alternative = InsertionResult::make_failure();
 
-                eval_job_insertion_in_route(insertion_ctx, &eval_ctx, &route_ctx, position, alternative)
+                eval_job_insertion_in_route(insertion_ctx, &mut eval_ctx, &route_ctx, position, alternative)
                     .try_into()
                     .ok()
                     .map(|success: InsertionSuccess| (success, Some(route_ctx)))

--- a/vrp-core/src/solver/search/recreate/mod.rs
+++ b/vrp-core/src/solver/search/recreate/mod.rs
@@ -98,7 +98,7 @@ impl Recreate for ConfigurableRecreate {
             insertion_ctx,
             self.job_selector.as_ref(),
             self.route_selector.as_ref(),
-            &self.leg_selection,
+            self.leg_selection.generate_copy(),
             result_selector,
         )
     }

--- a/vrp-core/src/solver/search/recreate/recreate_with_blinks.rs
+++ b/vrp-core/src/solver/search/recreate/recreate_with_blinks.rs
@@ -124,7 +124,7 @@ impl<T: LoadOps> RecreateWithBlinks<T> {
         Self {
             job_selectors: selectors.into_iter().map(|(selector, _)| selector).collect(),
             route_selector: Box::<AllRouteSelector>::default(),
-            leg_selection: LegSelection::Stochastic(random.clone()),
+            leg_selection: LegSelection::random_stochastic(&random),
             result_selector: Box::new(BlinkResultSelector::new_with_defaults(random)),
             insertion_heuristic: Default::default(),
             weights,
@@ -157,7 +157,7 @@ impl<T: LoadOps> Recreate for RecreateWithBlinks<T> {
             insertion_ctx,
             job_selector,
             self.route_selector.as_ref(),
-            &self.leg_selection,
+            self.leg_selection.generate_copy(),
             self.result_selector.as_ref(),
         )
     }

--- a/vrp-core/src/solver/search/recreate/recreate_with_cheapest.rs
+++ b/vrp-core/src/solver/search/recreate/recreate_with_cheapest.rs
@@ -18,7 +18,7 @@ impl RecreateWithCheapest {
             recreate: ConfigurableRecreate::new(
                 Box::<AllJobSelector>::default(),
                 Box::<AllRouteSelector>::default(),
-                LegSelection::Stochastic(random),
+                LegSelection::random_stochastic(&random),
                 ResultSelection::Concrete(Box::<BestResultSelector>::default()),
                 Default::default(),
             ),

--- a/vrp-core/src/solver/search/recreate/recreate_with_farthest.rs
+++ b/vrp-core/src/solver/search/recreate/recreate_with_farthest.rs
@@ -19,7 +19,7 @@ impl RecreateWithFarthest {
             recreate: ConfigurableRecreate::new(
                 Box::<AllJobSelector>::default(),
                 Box::<AllRouteSelector>::default(),
-                LegSelection::Stochastic(random),
+                LegSelection::random_stochastic(&random),
                 ResultSelection::Concrete(Box::<FarthestResultSelector>::default()),
                 Default::default(),
             ),

--- a/vrp-core/src/solver/search/recreate/recreate_with_gaps.rs
+++ b/vrp-core/src/solver/search/recreate/recreate_with_gaps.rs
@@ -35,7 +35,7 @@ impl RecreateWithGaps {
             recreate: ConfigurableRecreate::new(
                 Box::new(GapsJobSelector { min_jobs, max_jobs }),
                 Box::<AllRouteSelector>::default(),
-                LegSelection::Stochastic(random.clone()),
+                LegSelection::random_stochastic(&random),
                 ResultSelection::Stochastic(ResultSelectorProvider::new_default(random)),
                 Default::default(),
             ),

--- a/vrp-core/src/solver/search/recreate/recreate_with_nearest_neighbor.rs
+++ b/vrp-core/src/solver/search/recreate/recreate_with_nearest_neighbor.rs
@@ -17,7 +17,7 @@ impl RecreateWithNearestNeighbor {
             recreate: ConfigurableRecreate::new(
                 Box::<AllJobSelector>::default(),
                 Box::<AllRouteSelector>::default(),
-                LegSelection::Stochastic(random),
+                LegSelection::random_stochastic(&random),
                 ResultSelection::Concrete(Box::<BestResultSelector>::default()),
                 InsertionHeuristic::new(Box::new(PositionInsertionEvaluator::new(InsertionPosition::Last))),
             ),

--- a/vrp-core/src/solver/search/recreate/recreate_with_perturbation.rs
+++ b/vrp-core/src/solver/search/recreate/recreate_with_perturbation.rs
@@ -18,7 +18,7 @@ impl RecreateWithPerturbation {
             recreate: ConfigurableRecreate::new(
                 Box::<AllJobSelector>::default(),
                 Box::<AllRouteSelector>::default(),
-                LegSelection::Stochastic(random.clone()),
+                LegSelection::random_stochastic(&random),
                 ResultSelection::Concrete(Box::new(NoiseResultSelector::new(noise))),
                 Default::default(),
             ),

--- a/vrp-core/src/solver/search/recreate/recreate_with_skip_best.rs
+++ b/vrp-core/src/solver/search/recreate/recreate_with_skip_best.rs
@@ -25,7 +25,7 @@ impl RecreateWithSkipBest {
             recreate: ConfigurableRecreate::new(
                 Box::<AllJobSelector>::default(),
                 Box::<AllRouteSelector>::default(),
-                LegSelection::Stochastic(random.clone()),
+                LegSelection::random_stochastic(&random),
                 ResultSelection::Stochastic(ResultSelectorProvider::new_default(random)),
                 InsertionHeuristic::new(Box::new(SkipBestInsertionEvaluator::new(min, max))),
             ),
@@ -55,7 +55,7 @@ impl InsertionEvaluator for SkipBestInsertionEvaluator {
         insertion_ctx: &InsertionContext,
         job: &Job,
         routes: &[&RouteContext],
-        leg_selection: &LegSelection,
+        leg_selection: LegSelection,
         result_selector: &(dyn ResultSelector + Send + Sync),
     ) -> InsertionResult {
         self.fallback_evaluator.evaluate_job(insertion_ctx, job, routes, leg_selection, result_selector)
@@ -66,7 +66,7 @@ impl InsertionEvaluator for SkipBestInsertionEvaluator {
         insertion_ctx: &InsertionContext,
         route_ctx: &RouteContext,
         jobs: &[&Job],
-        leg_selection: &LegSelection,
+        leg_selection: LegSelection,
         result_selector: &(dyn ResultSelector + Send + Sync),
     ) -> InsertionResult {
         self.fallback_evaluator.evaluate_route(insertion_ctx, route_ctx, jobs, leg_selection, result_selector)
@@ -77,7 +77,7 @@ impl InsertionEvaluator for SkipBestInsertionEvaluator {
         insertion_ctx: &InsertionContext,
         jobs: &[&Job],
         routes: &[&RouteContext],
-        leg_selection: &LegSelection,
+        leg_selection: LegSelection,
         result_selector: &(dyn ResultSelector + Send + Sync),
     ) -> InsertionResult {
         let skip_index = insertion_ctx.environment.random.uniform_int(self.min as i32, self.max as i32);

--- a/vrp-core/src/solver/search/recreate/recreate_with_skip_random.rs
+++ b/vrp-core/src/solver/search/recreate/recreate_with_skip_random.rs
@@ -19,7 +19,7 @@ impl RecreateWithSkipRandom {
             recreate: ConfigurableRecreate::new(
                 Box::<SkipRandomJobSelector>::default(),
                 Box::<SkipRandomRouteSelector>::default(),
-                LegSelection::Stochastic(random.clone()),
+                LegSelection::random_stochastic(&random),
                 ResultSelection::Stochastic(ResultSelectorProvider::new_default(random)),
                 Default::default(),
             ),

--- a/vrp-core/src/solver/search/recreate/recreate_with_slice.rs
+++ b/vrp-core/src/solver/search/recreate/recreate_with_slice.rs
@@ -19,7 +19,7 @@ impl RecreateWithSlice {
             recreate: ConfigurableRecreate::new(
                 Box::<SliceJobSelector>::default(),
                 Box::<SliceRouteSelector>::default(),
-                LegSelection::Stochastic(random.clone()),
+                LegSelection::random_stochastic(&random),
                 ResultSelection::Stochastic(ResultSelectorProvider::new_default(random)),
                 Default::default(),
             ),

--- a/vrp-core/tests/unit/construction/heuristics/selectors_test.rs
+++ b/vrp-core/tests/unit/construction/heuristics/selectors_test.rs
@@ -81,7 +81,7 @@ mod selections {
 
     fn can_use_stochastic_selection_mode_impl(skip: usize, activities: usize, expected_threshold: usize) {
         let target = 10;
-        let selection_mode = LegSelection::Stochastic(Environment::default().random);
+        let mut selection_mode = LegSelection::random_stochastic(&Environment::default().random);
         let (_, solution) = generate_matrix_routes_with_defaults(activities, 1, false);
         let route_ctx = RouteContext::new_with_state(solution.routes.into_iter().next().unwrap(), Default::default());
         let mut counter = 0;

--- a/vrp-core/tests/unit/solver/search/local/exchange_swap_star_test.rs
+++ b/vrp-core/tests/unit/solver/search/local/exchange_swap_star_test.rs
@@ -41,7 +41,7 @@ fn create_insertion_ctx(
 }
 
 fn create_default_selectors() -> (LegSelection, BestResultSelector) {
-    let leg_selection = LegSelection::Stochastic(Environment::default().random);
+    let leg_selection = LegSelection::random_stochastic(&Environment::default().random);
     let result_selector = BestResultSelector::default();
 
     (leg_selection, result_selector)
@@ -128,7 +128,7 @@ fn can_exchange_jobs_in_routes() {
     rearrange_jobs_in_routes(&mut insertion_ctx, job_order.as_slice());
     let (leg_selection, result_selector) = create_default_selectors();
 
-    try_exchange_jobs_in_routes(&mut insertion_ctx, route_pair, &leg_selection, &result_selector);
+    try_exchange_jobs_in_routes(&mut insertion_ctx, route_pair, leg_selection, &result_selector);
 
     compare_with_ignore(get_customer_ids_from_routes(&insertion_ctx).as_slice(), &expected_route_ids, "");
 }
@@ -165,7 +165,7 @@ fn can_exchange_single_jobs_impl(
         create_insertion_success(&insertion_ctx, inner_insertion),
     );
 
-    try_exchange_jobs(&mut insertion_ctx, insertion_pair, &leg_selection, &result_selector);
+    try_exchange_jobs(&mut insertion_ctx, insertion_pair, leg_selection, &result_selector);
 
     compare_with_ignore(get_customer_ids_from_routes(&insertion_ctx).as_slice(), &expected_route_ids, "");
 }
@@ -184,7 +184,7 @@ fn can_find_insertion_cost_impl(job_id: &str, expected: Cost) {
     let matrix = (3, 1);
     let insertion_ctx = create_insertion_ctx(matrix, vec![], false);
     let (leg_selection, result_selector) = create_default_selectors();
-    let search_ctx: SearchContext = (&insertion_ctx, &leg_selection, &result_selector);
+    let search_ctx: SearchContext = (&insertion_ctx, leg_selection, &result_selector);
     let job = get_jobs_by_ids(&insertion_ctx, &[job_id]).first().cloned().unwrap();
     let route_ctx = insertion_ctx.solution.routes.first().unwrap();
 
@@ -217,7 +217,7 @@ fn can_find_in_place_result_impl(
     rearrange_jobs_in_routes(&mut insertion_ctx, job_order.as_slice());
     let (leg_selection, result_selector) = create_default_selectors();
     let jobs_map = get_jobs_map_by_ids(&insertion_ctx);
-    let search_ctx: SearchContext = (&insertion_ctx, &leg_selection, &result_selector);
+    let search_ctx: SearchContext = (&insertion_ctx, leg_selection, &result_selector);
     let route_ctx = insertion_ctx.solution.routes.get(route_idx).unwrap();
     let insert_job = jobs_map.get(insert_job).unwrap();
     let extract_job = jobs_map.get(extract_job).unwrap();
@@ -244,7 +244,7 @@ fn can_find_top_results_impl(job_id: &str, disallowed_pairs: Vec<(&str, &str)>, 
     let matrix = (5, 2);
     let insertion_ctx = create_insertion_ctx(matrix, disallowed_pairs, true);
     let (leg_selection, result_selector) = create_default_selectors();
-    let search_ctx: SearchContext = (&insertion_ctx, &leg_selection, &result_selector);
+    let search_ctx: SearchContext = (&insertion_ctx, leg_selection, &result_selector);
     let job_ids = get_jobs_by_ids(&insertion_ctx, &[job_id]);
     let route_ctx = insertion_ctx.solution.routes.first().unwrap();
 


### PR DESCRIPTION
## Summary

This is an experiment how a different usage of random number generators could improve CPU performance. The result is that `simple_multi_job_100_benchmark` takes 15% less time on an Apple M1 machine. This PR is not meant to be merged, but just an experiment.

## Motivation

To see potential performance issues, I profiled CPU usage of `simple_multi_job_100_benchmark` (The description in `Criterion` says "a problem with 50 multi jobs". This was done with the Mac application `Instruments`. Noticeable are calls to the random number generator which take a substantial percentage of the whole time.

![trace-vrp](https://github.com/carsten-wenderdel/vrp/assets/404173/cb18a045-9515-4c4a-b451-27be8d33f0ed)

## Analysis
`REPEATABLE_RNG` and `RANDOMIZED_RNG` are global / thread local mutable variables. They are used by a non mutable `Arc<dyn Random>`.
There are several performance costs connected to that, mainly:
- Smart pointers and dynamic dispatch
- Thread local variables, where initialisation has to be checked with every access.
- Branching via `if` to change between repeatable and non-deterministic behavior.

## Idea
Use a new struct `PureRandom` which encapsulated the random number generator and pass it directly without smart pointers to each function. This way Rust can use zero cost abstractions handling it. Also our functions become pure functions: If identically seeded RNGs are given as arguments, the return value will always be the same. This can also be helpful for deterministic unit and performance tests.

## Implementation
Not every usage of `Random` was replaced, only that in `LegSelection`. So most of `vrp` still uses the previous implementation. Now `LegSelection` needs to be mutable, so how this is handled in some `Contexts` had to be changed too - non mutable references don't work anymore here.

When used together with `Rayon`, each iteration needs a different `RNG`, so we need to create all of them before iteration. Each new `DefaultPureRandom` instance is different from each other, still everything is deterministic.

## Performance testing
In `general_benchmarks` I've changed the sample size from 15 to 100 to get more reliable results. The time estimate for `simple_multi_job_100_benchmark` changed from 2.3671 seconds to 1.9978 s. This is roughly 15% less time or from the perspective: Before the change roughly 18% more time was needed.

## Issues / Todos:
- Is `LegSelection` the right place to contain `PureRandom`? Maybe remove it from there so that `Stochastic` doesn't have any values. This way we could change the `contexts` to contain only non mutable references again. The `PureRandom` would then be passed to each function as a separate value - this would also work in other cases where randomness is needed but `LegSelection` is not used.
- Think again how new random structs are initialized. There are three ways: 1. Pseudo random based on a global/system RGN, 2. deterministic with a given seed, 3. a copy of an existing rng which then would return the same results. Which is best in which situation?
- Do we need `FakeRandom` for unit tests? Maybe deterministic behaviour is enough, otherwise we might want to make some structs and functions generic instead of using dynamic dispatch.
